### PR TITLE
BipedRetargetingSolver implementation

### DIFF
--- a/DFG/Kinematics/BipedRetargtingSolver/BipedRetargetingSolver.canvas
+++ b/DFG/Kinematics/BipedRetargtingSolver/BipedRetargetingSolver.canvas
@@ -1,0 +1,639 @@
+{
+  "objectType" : "Graph",
+  "metadata" : {
+    "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+    "uiNodeColor" : "{\n  \"r\" : 59,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+    "uiGraphZoom" : "{\n  \"value\" : 0.8299146890640259\n  }",
+    "uiTooltip" : "Retargets the current pose of a biped character based on the pose of another biped character. Mappings are defined using JSON files and MotionBuilder naming convention. The offset between character joints is defined based on the poses at a given reference frame.",
+    "uiGraphPan" : "{\n  \"x\" : -630.3634033203125,\n  \"y\" : -139.8838806152344\n  }"
+    },
+  "title" : "BipedRetargetingSolver",
+  "ports" : [
+    {
+      "objectType" : "ExecPort",
+      "name" : "exec",
+      "nodePortType" : "IO",
+      "defaultValues" : {
+        "Execute" : {}
+        },
+      "execPortType" : "IO",
+      "typeSpec" : "Execute"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "drawDebug",
+      "nodePortType" : "Out",
+      "defaultValues" : {
+        "Boolean" : false
+        },
+      "execPortType" : "In",
+      "typeSpec" : "Boolean"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "scaleFactor",
+      "nodePortType" : "Out",
+      "defaultValues" : {
+        "Scalar" : 1
+        },
+      "execPortType" : "In"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inCharacter",
+      "nodePortType" : "Out",
+      "defaultValues" : {
+        "ICharacter" : null
+        },
+      "execPortType" : "In",
+      "typeSpec" : "ICharacter"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inNameTemplate",
+      "nodePortType" : "Out",
+      "defaultValues" : {
+        "String" : ""
+        },
+      "execPortType" : "In"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outCharacter",
+      "nodePortType" : "Out",
+      "defaultValues" : {
+        "Character" : null
+        },
+      "execPortType" : "In"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outNameTemplate",
+      "nodePortType" : "Out",
+      "defaultValues" : {
+        "String" : ""
+        },
+      "execPortType" : "In"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inRefFrame",
+      "nodePortType" : "Out",
+      "defaultValues" : {
+        "Scalar" : 0
+        },
+      "execPortType" : "In",
+      "typeSpec" : "Scalar"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outRefFrame",
+      "nodePortType" : "Out",
+      "defaultValues" : {
+        "Scalar" : 0
+        },
+      "execPortType" : "In",
+      "typeSpec" : "Scalar"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "retargetPose",
+      "nodePortType" : "In",
+      "defaultValues" : {
+        "IPose" : null
+        },
+      "execPortType" : "Out"
+      }
+    ],
+  "extDeps" : {
+    "fabricUtils" : "*"
+    },
+  "presetGUID" : "5BEE128DCD8CBA5159B569D2AF31778F",
+  "nodes" : [
+    {
+      "objectType" : "Var",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":800.413125277,\"y\":132.23861742}"
+        },
+      "name" : "solver",
+      "ports" : [
+        {
+          "objectType" : "VarPort",
+          "name" : "value",
+          "nodePortType" : "IO"
+          }
+        ],
+      "dataType" : "BipedRetargetingSolver"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":473.980339527,\"y\":127.584055901}"
+        },
+      "name" : "BipedRetargetingSolver_Constructor_1",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "result",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Constructor",
+      "presetGUID" : "5DA31A7CEEF572CC1872C28626061AC2"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":917.399583817,\"y\":160.117748737}"
+        },
+      "name" : "BipedRetargetingSolver_Solve_1",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "this",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "drawDebug",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "scaleFactor",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "inCharacter",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "outCharacter",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "inNameTemplate",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "outNameTemplate",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "inRefFrame",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "outRefFrame",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "retargetPose",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Solve",
+      "presetGUID" : "27B880C6D5A791F0E845044FA61D58F7"
+      }
+    ],
+  "connections" : {
+    "drawDebug" : [
+      "BipedRetargetingSolver_Solve_1.drawDebug"
+      ],
+    "scaleFactor" : [
+      "BipedRetargetingSolver_Solve_1.scaleFactor"
+      ],
+    "inCharacter" : [
+      "BipedRetargetingSolver_Solve_1.inCharacter"
+      ],
+    "inNameTemplate" : [
+      "BipedRetargetingSolver_Solve_1.inNameTemplate"
+      ],
+    "outCharacter" : [
+      "BipedRetargetingSolver_Solve_1.outCharacter"
+      ],
+    "outNameTemplate" : [
+      "BipedRetargetingSolver_Solve_1.outNameTemplate"
+      ],
+    "inRefFrame" : [
+      "BipedRetargetingSolver_Solve_1.inRefFrame"
+      ],
+    "outRefFrame" : [
+      "BipedRetargetingSolver_Solve_1.outRefFrame"
+      ],
+    "solver.value" : [
+      "BipedRetargetingSolver_Solve_1.this"
+      ],
+    "BipedRetargetingSolver_Constructor_1.result" : [
+      "solver.value"
+      ],
+    "BipedRetargetingSolver_Solve_1.retargetPose" : [
+      "retargetPose"
+      ]
+    },
+  "requiredPresets" : {
+    "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver" : {
+      "objectType" : "Graph",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 59,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+        "uiGraphZoom" : "{\n  \"value\" : 0.8299146890640259\n  }",
+        "uiTooltip" : "Retargets the current pose of a biped character based on the pose of another biped character. Mappings are defined using JSON files and MotionBuilder naming convention. The offset between character joints is defined based on the poses at a given reference frame.",
+        "uiGraphPan" : "{\n  \"x\" : -630.3634033203125,\n  \"y\" : -139.8838806152344\n  }"
+        },
+      "title" : "BipedRetargetingSolver",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "defaultValues" : {
+            "Execute" : {}
+            },
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "drawDebug",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Boolean" : false
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Boolean"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "scaleFactor",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Scalar" : 1
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inCharacter",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "ICharacter" : null
+            },
+          "execPortType" : "In",
+          "typeSpec" : "ICharacter"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inNameTemplate",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "String" : ""
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outCharacter",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Character" : null
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outNameTemplate",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "String" : ""
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inRefFrame",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Scalar" : 0
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outRefFrame",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Scalar" : 0
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "retargetPose",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "IPose" : null
+            },
+          "execPortType" : "Out"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "5BEE128DCD8CBA5159B569D2AF31778F",
+      "nodes" : [
+        {
+          "objectType" : "Var",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":800.413125277,\"y\":132.23861742}"
+            },
+          "name" : "solver",
+          "ports" : [
+            {
+              "objectType" : "VarPort",
+              "name" : "value",
+              "nodePortType" : "IO"
+              }
+            ],
+          "dataType" : "BipedRetargetingSolver"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":473.980339527,\"y\":127.584055901}"
+            },
+          "name" : "BipedRetargetingSolver_Constructor_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Constructor",
+          "presetGUID" : "5DA31A7CEEF572CC1872C28626061AC2"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":917.399583817,\"y\":160.117748737}"
+            },
+          "name" : "BipedRetargetingSolver_Solve_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "drawDebug",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "scaleFactor",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "inCharacter",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "outCharacter",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "inNameTemplate",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "outNameTemplate",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "inRefFrame",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "outRefFrame",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "retargetPose",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Solve",
+          "presetGUID" : "27B880C6D5A791F0E845044FA61D58F7"
+          }
+        ],
+      "connections" : {
+        "drawDebug" : [
+          "BipedRetargetingSolver_Solve_1.drawDebug"
+          ],
+        "scaleFactor" : [
+          "BipedRetargetingSolver_Solve_1.scaleFactor"
+          ],
+        "inCharacter" : [
+          "BipedRetargetingSolver_Solve_1.inCharacter"
+          ],
+        "inNameTemplate" : [
+          "BipedRetargetingSolver_Solve_1.inNameTemplate"
+          ],
+        "outCharacter" : [
+          "BipedRetargetingSolver_Solve_1.outCharacter"
+          ],
+        "outNameTemplate" : [
+          "BipedRetargetingSolver_Solve_1.outNameTemplate"
+          ],
+        "inRefFrame" : [
+          "BipedRetargetingSolver_Solve_1.inRefFrame"
+          ],
+        "outRefFrame" : [
+          "BipedRetargetingSolver_Solve_1.outRefFrame"
+          ],
+        "solver.value" : [
+          "BipedRetargetingSolver_Solve_1.this"
+          ],
+        "BipedRetargetingSolver_Constructor_1.result" : [
+          "solver.value"
+          ],
+        "BipedRetargetingSolver_Solve_1.retargetPose" : [
+          "retargetPose"
+          ]
+        }
+      },
+    "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Constructor" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 49,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+        "uiHeaderColor" : "{\n  \"r\" : 42,\n  \"g\" : 94,\n  \"b\" : 102\n  }",
+        "uiTooltip" : "Supported types:\n  result: BipedRetargetingSolver\n"
+        },
+      "title" : "BipedRetargetingSolver_Constructor",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "BipedRetargetingSolver"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "5DA31A7CEEF572CC1872C28626061AC2",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  result = BipedRetargetingSolver();
+}
+"
+      },
+    "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Solve" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 49,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+        "uiHeaderColor" : "{\n  \"r\" : 42,\n  \"g\" : 94,\n  \"b\" : 102\n  }",
+        "uiTooltip" : "Supported types:\n  this: BipedRetargetingSolver\n  drawDebug: Boolean\n  scaleFactor: Scalar\n  inCharacter: ICharacter\n  outCharacter: ICharacter\n  inNameTemplate: FilePath\n  outNameTemplate: FilePath\n  inRefFrame: Scalar\n  outRefFrame: Scalar\n  retargetPose: IPose\n"
+        },
+      "title" : "BipedRetargetingSolver_Solve",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "BipedRetargetingSolver"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "drawDebug",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Boolean"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "scaleFactor",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inCharacter",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "ICharacter"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outCharacter",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "ICharacter"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inNameTemplate",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "FilePath"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outNameTemplate",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "FilePath"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inRefFrame",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outRefFrame",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "retargetPose",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "IPose"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "27B880C6D5A791F0E845044FA61D58F7",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  this.solve(drawDebug, scaleFactor, inCharacter, outCharacter, inNameTemplate, outNameTemplate, inRefFrame, outRefFrame, retargetPose);
+}
+"
+      }
+    }
+  }

--- a/DFG/Kinematics/BipedRetargtingSolver/BipedRetargetingSolver_Constructor.canvas
+++ b/DFG/Kinematics/BipedRetargtingSolver/BipedRetargetingSolver_Constructor.canvas
@@ -1,0 +1,37 @@
+// Created by kl2dfg (processFunction)
+{
+  "objectType" : "Func",
+  "metadata" : {
+    "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+    "uiNodeColor" : "{\n  \"r\" : 49,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+    "uiHeaderColor" : "{\n  \"r\" : 42,\n  \"g\" : 94,\n  \"b\" : 102\n  }",
+    "uiTooltip" : "Supported types:\n  result: BipedRetargetingSolver\n"
+    },
+  "title" : "BipedRetargetingSolver_Constructor",
+  "ports" : [
+    {
+      "objectType" : "ExecPort",
+      "name" : "exec",
+      "nodePortType" : "IO",
+      "execPortType" : "IO",
+      "typeSpec" : "Execute"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "result",
+      "nodePortType" : "In",
+      "execPortType" : "Out",
+      "typeSpec" : "BipedRetargetingSolver"
+      }
+    ],
+  "extDeps" : {
+    "fabricUtils" : "*"
+    },
+  "presetGUID" : "5DA31A7CEEF572CC1872C28626061AC2",
+  "code" : "require fabricUtils;
+
+dfgEntry {
+  result = BipedRetargetingSolver();
+}
+"
+  }

--- a/DFG/Kinematics/BipedRetargtingSolver/BipedRetargetingSolver_Init.canvas
+++ b/DFG/Kinematics/BipedRetargtingSolver/BipedRetargetingSolver_Init.canvas
@@ -1,0 +1,79 @@
+// Created by kl2dfg (processFunction)
+{
+  "objectType" : "Func",
+  "metadata" : {
+    "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+    "uiNodeColor" : "{\n  \"r\" : 49,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+    "uiHeaderColor" : "{\n  \"r\" : 42,\n  \"g\" : 94,\n  \"b\" : 102\n  }",
+    "uiTooltip" : "Supported types:\n  this: BipedRetargetingSolver\n  inCharacter: ICharacter\n  outCharacter: ICharacter\n  inNameTemplate: FilePath\n  outNameTemplate: FilePath\n  inRefFrame: Scalar\n  outRefFrame: Scalar\n"
+    },
+  "title" : "BipedRetargetingSolver_Init",
+  "ports" : [
+    {
+      "objectType" : "ExecPort",
+      "name" : "exec",
+      "nodePortType" : "IO",
+      "execPortType" : "IO",
+      "typeSpec" : "Execute"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "this",
+      "nodePortType" : "IO",
+      "execPortType" : "IO",
+      "typeSpec" : "BipedRetargetingSolver"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inCharacter",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "ICharacter"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outCharacter",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "ICharacter"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inNameTemplate",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "FilePath"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outNameTemplate",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "FilePath"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inRefFrame",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "Scalar"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outRefFrame",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "Scalar"
+      }
+    ],
+  "extDeps" : {
+    "fabricUtils" : "*"
+    },
+  "presetGUID" : "66341CEBF179A12A91130437930D523D",
+  "code" : "require fabricUtils;
+
+dfgEntry {
+  this.init(inCharacter, outCharacter, inNameTemplate, outNameTemplate, inRefFrame, outRefFrame);
+}
+"
+  }

--- a/DFG/Kinematics/BipedRetargtingSolver/BipedRetargetingSolver_Solve.canvas
+++ b/DFG/Kinematics/BipedRetargtingSolver/BipedRetargetingSolver_Solve.canvas
@@ -1,0 +1,100 @@
+// Created by kl2dfg (processFunction)
+{
+  "objectType" : "Func",
+  "metadata" : {
+    "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+    "uiNodeColor" : "{\n  \"r\" : 49,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+    "uiHeaderColor" : "{\n  \"r\" : 42,\n  \"g\" : 94,\n  \"b\" : 102\n  }",
+    "uiTooltip" : "Supported types:\n  this: BipedRetargetingSolver\n  drawDebug: Boolean\n  scaleFactor: Scalar\n  inCharacter: ICharacter\n  outCharacter: ICharacter\n  inNameTemplate: FilePath\n  outNameTemplate: FilePath\n  inRefFrame: Scalar\n  outRefFrame: Scalar\n  retargetPose: IPose\n"
+    },
+  "title" : "BipedRetargetingSolver_Solve",
+  "ports" : [
+    {
+      "objectType" : "ExecPort",
+      "name" : "exec",
+      "nodePortType" : "IO",
+      "execPortType" : "IO",
+      "typeSpec" : "Execute"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "this",
+      "nodePortType" : "IO",
+      "execPortType" : "IO",
+      "typeSpec" : "BipedRetargetingSolver"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "drawDebug",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "Boolean"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "scaleFactor",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "Scalar"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inCharacter",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "ICharacter"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outCharacter",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "ICharacter"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inNameTemplate",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "FilePath"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outNameTemplate",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "FilePath"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "inRefFrame",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "Scalar"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "outRefFrame",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "Scalar"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "retargetPose",
+      "nodePortType" : "In",
+      "execPortType" : "Out",
+      "typeSpec" : "IPose"
+      }
+    ],
+  "extDeps" : {
+    "fabricUtils" : "*"
+    },
+  "presetGUID" : "27B880C6D5A791F0E845044FA61D58F7",
+  "code" : "require fabricUtils;
+
+dfgEntry {
+  this.solve(drawDebug, scaleFactor, inCharacter, outCharacter, inNameTemplate, outNameTemplate, inRefFrame, outRefFrame, retargetPose);
+}
+"
+  }

--- a/FileIO/BVHReader.kl
+++ b/FileIO/BVHReader.kl
@@ -38,9 +38,10 @@ function BVHReader.read!() {
 /// After reading is done and all data is stored in memory this method sets up a Character object.
 function BVHReader.setCharacter!() {
   ClipPose cp = ClipPose(this.skeleton, this.clip);
-  this.character = Character();
+  this.character = Character(this.filePath.fileName());
   this.character.setSkeleton(this.skeleton);
   this.character.setPose(cp);
+  this.character.incrementVersion();
 }
 
 /// \dfgPresetFolder FileIO\BVHReader

--- a/Kinematics/BipedRetargetingSolver.kl
+++ b/Kinematics/BipedRetargetingSolver.kl
@@ -1,0 +1,283 @@
+require FileIO;
+require JSON;
+require Characters;
+
+object BipedRetargetingSolver {
+  Boolean drawDebug;
+  Scalar scaleFactor;
+  Character inCharacter;
+  Character outCharacter;
+  FilePath inNameTemplate;
+  FilePath outNameTemplate;
+  Scalar inRefFrame;
+  Scalar outRefFrame;
+  IPose inRefPose;
+  IPose outRefPose;
+  String luWorld[];
+  String luRequired[];
+  String luSpine[];
+  String luAuxilary[];
+  JSONDictValue inWorldNames;
+  Index inWorldIds[];
+  JSONDictValue outWorldNames;
+  Index outWorldIds[];
+  Index outWorldParents[];
+  JSONDictValue inRequiredNames;
+  Index inRequiredIds[];
+  JSONDictValue outRequiredNames;
+  Index outRequiredIds[];
+  Index outRequiredParents[];
+  JSONDictValue inSpineNames;
+  Index inSpineIds[];
+  JSONDictValue outSpineNames;
+  Index outSpineIds[];
+  Index outSpineParents[];
+  JSONDictValue inAuxilaryNames;
+  Index inAuxilaryIds[];
+  JSONDictValue outAuxilaryNames;
+  Index outAuxilaryIds[];
+  Index outAuxilaryParents[];
+};
+
+/// \dfgPresetTitle BipedRetargetingSolver_Constructor
+/// \dfgPresetColor Color(49, 60, 61)
+/// \dfgPresetHeaderColor Color(42, 94, 102)
+/// \dfgPresetTextColor Color(168, 229, 240)
+/// \dfgPresetFolder Kinematics\BipedRetargtingSolver
+function BipedRetargetingSolver(
+  ) {
+
+}
+
+/// \dfgPresetTitle BipedRetargetingSolver_Init
+/// \dfgPresetColor Color(49, 60, 61)
+/// \dfgPresetHeaderColor Color(42, 94, 102)
+/// \dfgPresetTextColor Color(168, 229, 240)
+/// \dfgPresetFolder Kinematics\BipedRetargtingSolver
+function BipedRetargetingSolver.init!(
+  in ICharacter inCharacter,
+  in ICharacter outCharacter,
+  in FilePath inNameTemplate,
+  in FilePath outNameTemplate,
+  in Scalar inRefFrame,
+  in Scalar outRefFrame
+  ) {
+  report('initiating default values');
+  this.inCharacter = inCharacter;
+  this.outCharacter = outCharacter;
+  this.inNameTemplate = inNameTemplate;
+  this.outNameTemplate = outNameTemplate;
+  this.changeRefFrame(inRefFrame, outRefFrame);
+
+  report('initiating indices mapping');
+  this.fillLookups();
+  this.fillMappingNames();
+  this.fillMappingIndices();
+}
+
+/// \dfgPresetTitle BipedRetargetingSolver_Solve
+/// \dfgPresetColor Color(49, 60, 61)
+/// \dfgPresetHeaderColor Color(42, 94, 102)
+/// \dfgPresetTextColor Color(168, 229, 240)
+/// \dfgPresetFolder Kinematics\BipedRetargtingSolver
+function BipedRetargetingSolver.solve!(
+  in Boolean drawDebug,
+  in Scalar scaleFactor,
+  in ICharacter inCharacter,
+  in ICharacter outCharacter,
+  in FilePath inNameTemplate,
+  in FilePath outNameTemplate,
+  in Scalar inRefFrame,
+  in Scalar outRefFrame,
+  out IPose retargetPose
+  ) {
+  if(inNameTemplate.string() != this.inNameTemplate.string() || outNameTemplate.string() != this.outNameTemplate.string())
+    this.init(inCharacter, outCharacter, inNameTemplate, outNameTemplate, inRefFrame, outRefFrame);
+  else if(this.inCharacter.getName() != inCharacter.getName() || this.outCharacter.getName() != outCharacter.getName())
+    this.init(inCharacter, outCharacter, inNameTemplate, outNameTemplate, inRefFrame, outRefFrame);  
+  else if(inRefFrame != this.inRefFrame || outRefFrame != this.outRefFrame)
+    this.changeRefFrame(inRefFrame, outRefFrame);
+  else if(scaleFactor != this.scaleFactor)
+    this.changeRefFrame(inRefFrame, outRefFrame);
+
+  IPose inPose = this.inCharacter.getPose().clone();
+  IPose outPose = this.outCharacter.getPose().clone().reset();
+
+  this.scaleFactor = scaleFactor;
+  Xfo scaleXfo(scaleFactor, scaleFactor, scaleFactor, 0, 0, 0, 0, 0, 0);
+
+  // world xfo retargeting
+  Index inWorldXfoIds[] = this.inWorldIds.clone();
+  Index outWorldXfoIds[] = this.outWorldIds.clone();
+  inWorldXfoIds.push(this.inRequiredIds[0]);
+  outWorldXfoIds.push(this.outRequiredIds[0]);
+
+  for(Size i=0; i<inWorldXfoIds.size(); i++) {
+    Index inId = inWorldXfoIds[i];
+    Index outId = outWorldXfoIds[i];
+    
+    Xfo riXfo = this.inRefPose.getBoneXfo(inId);
+    Xfo roXfo = this.outRefPose.getBoneXfo(outId);
+    
+    Xfo offset = riXfo.inverse()*roXfo;
+    
+    Xfo ixfo = inPose.getBoneXfo(inId);
+    Xfo oxfo = outPose.getBoneXfo(outId);
+    
+    oxfo = offset*ixfo;
+    oxfo = ixfo*scaleXfo;
+
+    outPose.setBoneXfo(outId, oxfo);
+  }
+  
+  Xfo hipsXfo = outPose.getBoneXfo(outWorldXfoIds[outWorldXfoIds.size()-1]);
+
+  // orientation only retargeting
+  Index inOrientationIds[];
+  Index outOrientationIds[];
+  inOrientationIds = this.inRequiredIds + this.inSpineIds + this.inAuxilaryIds;
+  outOrientationIds = this.outRequiredIds + this.outSpineIds + this.outAuxilaryIds;
+
+  for(Size i=0; i<inOrientationIds.size(); i++) {
+    Index inId = inOrientationIds[i];
+    Index outId = outOrientationIds[i];
+    
+    Quat riXfo = this.inRefPose.getBoneXfo(inId).ori;
+    Quat roXfo = this.outRefPose.getBoneXfo(outId).ori;
+    
+    Quat offset = riXfo.inverse()*roXfo;
+    
+    Xfo ixfo = hipsXfo.inverse()*inPose.getBoneXfo(inId);
+    Xfo oxfo = outPose.getBoneXfo(outId);
+
+    oxfo.ori = offset*ixfo.ori;
+    oxfo.ori = hipsXfo.ori*oxfo.ori;
+
+    outPose.setBoneXfo(outId, oxfo);
+  }
+
+  retargetPose = outPose;
+
+}
+
+/// \dfgPresetOmit
+function BipedRetargetingSolver.changeRefFrame!(
+  in Scalar inRefFrame,
+  in Scalar outRefFrame
+  ) {
+  this.inRefFrame = inRefFrame;
+  this.outRefFrame = outRefFrame;
+  this.inRefPose = this.inCharacter.setClipPoseTime(inRefFrame).getPose().clone();
+  this.outRefPose = this.outCharacter.setClipPoseTime(outRefFrame).getPose().clone();
+}
+
+/// \dfgPresetOmit
+function BipedRetargetingSolver.fillLookups!() {
+  // prepare lookup arrays
+    // world pos. xfos
+  this.luWorld.push("Reference");
+  this.luWorld.push("LeftFootFloor");
+  this.luWorld.push("RightFootFloor");
+  this.luWorld.push("LeftHandFloor");
+  this.luWorld.push("RightHandFloor");
+    // required joints
+  this.luRequired.push("Hips");
+  this.luRequired.push("LeftUpLeg");
+  this.luRequired.push("LeftLeg");
+  this.luRequired.push("LeftFoot");
+  this.luRequired.push("RightUpLeg");
+  this.luRequired.push("RightLeg");
+  this.luRequired.push("RightFoot");
+  this.luRequired.push("LeftArm");
+  this.luRequired.push("LeftForeArm");
+  this.luRequired.push("LeftHand");
+  this.luRequired.push("RightArm");
+  this.luRequired.push("RightForeArm");
+  this.luRequired.push("RightHand");
+  this.luRequired.push("Head");
+    // spine (variable n. of joints)
+  this.luSpine.push("Spine");
+  for(Size i=1; i<10; i++) {
+    this.luSpine.push("Spine" + i);
+  }
+    // auxilary joints
+  this.luAuxilary.push("LeftToeBase");
+  this.luAuxilary.push("RightToeBase");
+  this.luAuxilary.push("LeftShoulder");
+  this.luAuxilary.push("RightShoulder");
+  this.luAuxilary.push("Neck");
+  this.luAuxilary.push("LeftFingerBase");
+  this.luAuxilary.push("RightFingerBase");
+}
+
+/// \dfgPresetOmit
+function BipedRetargetingSolver.fillMappingNames!() {
+  // read input template
+  TextReader reader = TextReader(this.inNameTemplate.string());
+  String data = reader.readAll();
+  JSONDoc inDoc();
+  inDoc.parse(data);
+  this.inWorldNames  = inDoc.root.get('worldPos');
+  this.inRequiredNames  = inDoc.root.get('required');
+  this.inSpineNames  = inDoc.root.get('spine');
+  this.inAuxilaryNames  = inDoc.root.get('auxilary');
+  
+  // read output template
+  reader = TextReader(this.outNameTemplate.string());
+  data = reader.readAll();
+  JSONDoc outDoc();
+  outDoc.parse(data);
+  this.outWorldNames  = outDoc.root.get('worldPos');
+  this.outRequiredNames  = outDoc.root.get('required');
+  this.outSpineNames  = outDoc.root.get('spine');
+  this.outAuxilaryNames  = outDoc.root.get('auxilary');
+}
+
+/// \dfgPresetOmit
+function BipedRetargetingSolver.fillMappingIndices!() {
+  this.mapNamesToIndices(this.luWorld, this.inWorldNames, this.outWorldNames, true, false, this.inWorldIds, this.outWorldIds, this.outWorldParents);
+  this.mapNamesToIndices(this.luRequired, this.inRequiredNames, this.outRequiredNames,true, true, this.inRequiredIds, this.outRequiredIds, this.outRequiredParents);
+  this.mapNamesToIndices(this.luSpine, this.inSpineNames, this.outSpineNames,false, false, this.inSpineIds, this.outSpineIds, this.outSpineParents);
+  this.mapNamesToIndices(this.luAuxilary, this.inAuxilaryNames, this.outAuxilaryNames,true, false, this.inAuxilaryIds, this.outAuxilaryIds, this.outAuxilaryParents);
+}
+
+/// \dfgPresetOmit
+function BipedRetargetingSolver.mapNamesToIndices!(
+  in String lookup[],
+  in JSONDictValue inData,
+  in JSONDictValue outData,
+  in Boolean pair,
+  in Boolean enforce,
+  out Index inIds[],
+  out Index outIds[],
+  out Index parentIds[]
+){
+  String inNames[];
+  String outNames[];
+  for(Size i=0; i<lookup.size(); i++){
+    String l = lookup[i];
+    if(pair) {
+      if(inData.has(l) && outData.has(l)) {
+        inNames.push(inData.getString(l));
+        outNames.push(outData.getString(l));
+      }
+      else if(enforce && ~inData.has(l))
+        setError(l + ' node is mandatory, but was not found in the input mapping file.');
+      else if(enforce && ~outData.has(l))
+        setError(l + ' node is mandatory, but was not found in the output mapping file.');
+    }
+    else {
+      if(inData.has(l))
+        inNames.push(inData.getString(l));
+      else if(enforce && ~inData.has(l))
+        setError(l + ' node is mandatory, but was not found in the input mapping file.');
+      if(outData.has(l))
+        outNames.push(outData.getString(l));
+      else if(enforce && ~inData.has(l))
+        setError(l + ' node is mandatory, but was not found in the input mapping file.');  
+  }
+  }
+  inIds = boneNameArrayToIDArray(this.inCharacter.skeleton,inNames);
+  outIds = boneNameArrayToIDArray(this.outCharacter.skeleton,outNames);
+  parentIds = boneIDArrayToParentIDArray(this.outCharacter.skeleton,outIds);
+}

--- a/README.MD
+++ b/README.MD
@@ -10,3 +10,6 @@ Presets for converting a pose or reference pose to Xfo arrays, CSV strings, and 
 
 ### FileIO
 Reading and writing character pose clips to CSV files (quaternions only). Reading of BVH files (limited to local orientation of joints, reads translation only from the root node).
+
+### Kinematics
+Very basic retargeting. Basicly just name mapping and orientation transfers. No footskating preventing fullbody-ik techniques at the moment.

--- a/Samples/characterMaping - CMU.json
+++ b/Samples/characterMaping - CMU.json
@@ -1,0 +1,36 @@
+{
+	"name":"CMU_mobuBVH",
+	"worldPos": {
+	},
+	"required": {
+		"Hips":"Hips",
+		"LeftUpLeg":"LeftUpLeg",
+		"LeftLeg":"LeftLeg",
+		"LeftFoot":"LeftFoot",
+		"RightUpLeg":"RightUpLeg",
+		"RightLeg":"RightLeg",
+		"RightFoot":"RightFoot",
+		"LeftArm":"LeftArm",
+		"LeftForeArm":"LeftForeArm",
+		"LeftHand":"LeftHand",
+		"RightArm":"RightArm",
+		"RightForeArm":"RightForeArm",
+		"RightHand":"RightHand",
+		"Head":"Head"
+	},
+	"spine":
+	{
+		"Spine":"LowerBack",
+		"Spine1":"Spine",
+		"Spine2":"Spine1"
+	},
+	"auxilary": {
+		"LeftToeBase":"LeftToeBase",
+		"RightToeBase":"RightToeBase",
+		"LeftShoulder":"LeftShoulder",
+		"RightShoulder":"RightShoulder",
+		"Neck":"Neck",
+		"LeftFingerBase":"LeftFingerBase",
+		"RightFingerBase":"RightFingerBase"
+	}
+}

--- a/Samples/characterMaping - SMPLfemale.json
+++ b/Samples/characterMaping - SMPLfemale.json
@@ -1,0 +1,37 @@
+{
+	"name":"SMPL_female",
+	"worldPos": {
+		"Reference":"f_avg_root"
+	},
+	"required": {
+		"Hips":"f_avg_Pelvis",
+		"LeftUpLeg":"f_avg_L_Hip",
+		"LeftLeg":"f_avg_L_Knee",
+		"LeftFoot":"f_avg_L_Ankle",
+		"RightUpLeg":"f_avg_R_Hip",
+		"RightLeg":"f_avg_R_Knee",
+		"RightFoot":"f_avg_R_Ankle",
+		"LeftArm":"f_avg_L_Shoulder",
+		"LeftForeArm":"f_avg_L_Elbow",
+		"LeftHand":"f_avg_L_Wrist",
+		"RightArm":"f_avg_R_Shoulder",
+		"RightForeArm":"f_avg_R_Elbow",
+		"RightHand":"f_avg_R_Wrist",
+		"Head":"f_avg_Head"
+	},
+	"spine":
+	{
+		"Spine":"f_avg_Spine1",
+		"Spine1":"f_avg_Spine2",
+		"Spine2":"f_avg_Spine3"
+	},
+	"auxilary": {
+		"LeftToeBase":"f_avg_L_Foot",
+		"RightToeBase":"f_avg_R_Foot",
+		"LeftShoulder":"f_avg_L_Collar",
+		"RightShoulder":"f_avg_R_Collar",
+		"Neck":"f_avg_Neck",
+		"LeftFingerBase":"f_avg_L_Hand",
+		"RightFingerBase":"f_avg_R_Hand"
+	}
+}

--- a/Samples/characterMaping - SMPLmale.json
+++ b/Samples/characterMaping - SMPLmale.json
@@ -1,0 +1,37 @@
+{
+	"name":"SMPL_male",
+	"worldPos": {
+		"Reference":"m_avg_root"
+	},
+	"required": {
+		"Hips":"m_avg_Pelvis",
+		"LeftUpLeg":"m_avg_L_Hip",
+		"LeftLeg":"m_avg_L_Knee",
+		"LeftFoot":"m_avg_L_Ankle",
+		"RightUpLeg":"m_avg_R_Hip",
+		"RightLeg":"m_avg_R_Knee",
+		"RightFoot":"m_avg_R_Ankle",
+		"LeftArm":"m_avg_L_Shoulder",
+		"LeftForeArm":"m_avg_L_Elbow",
+		"LeftHand":"m_avg_L_Wrist",
+		"RightArm":"m_avg_R_Shoulder",
+		"RightForeArm":"m_avg_R_Elbow",
+		"RightHand":"m_avg_R_Wrist",
+		"Head":"m_avg_Head"
+	},
+	"spine":
+	{
+		"Spine":"m_avg_Spine1",
+		"Spine1":"m_avg_Spine2",
+		"Spine2":"m_avg_Spine3"
+	},
+	"auxilary": {
+		"LeftToeBase":"m_avg_L_Foot",
+		"RightToeBase":"m_avg_R_Foot",
+		"LeftShoulder":"m_avg_L_Collar",
+		"RightShoulder":"m_avg_R_Collar",
+		"Neck":"m_avg_Neck",
+		"LeftFingerBase":"m_avg_L_Hand",
+		"RightFingerBase":"m_avg_R_Hand"
+	}
+}

--- a/Samples/retargeting.canvas
+++ b/Samples/retargeting.canvas
@@ -1,0 +1,3933 @@
+{
+  "objectType" : "Graph",
+  "metadata" : {
+    "camera_mat44" : "{\n  \"row0\" : {\n    \"x\" : 0.3439281284809113,\n    \"y\" : 0.1035803481936455,\n    \"z\" : -0.9333533644676209,\n    \"t\" : -85.49921417236328\n    },\n  \"row1\" : {\n    \"x\" : 3.759124410862569e-06,\n    \"y\" : 0.9938256740570068,\n    \"z\" : 0.1103269532322884,\n    \"t\" : 34.42546844482422\n    },\n  \"row2\" : {\n    \"x\" : 0.9390828609466553,\n    \"y\" : -0.03793907538056374,\n    \"z\" : 0.341829389333725,\n    \"t\" : 48.51362228393555\n    },\n  \"row3\" : {\n    \"x\" : 0,\n    \"y\" : 0,\n    \"z\" : 0,\n    \"t\" : 1\n    }\n  }",
+    "timeline_start" : "0",
+    "timeline_loopMode" : "1",
+    "uiGraphZoom" : "{\n  \"value\" : 0.4478699862957001\n  }",
+    "timeline_simMode" : "0",
+    "camera_focalDistance" : "107.9601135253906",
+    "timeline_current" : "223",
+    "timeline_end" : "400",
+    "uiGraphPan" : "{\n  \"x\" : -205.4975425239632,\n  \"y\" : 215.1757666123295\n  }"
+    },
+  "title" : "",
+  "ports" : [
+    {
+      "objectType" : "ExecPort",
+      "name" : "exec",
+      "nodePortType" : "IO",
+      "execPortType" : "IO",
+      "typeSpec" : "Execute"
+      },
+    {
+      "objectType" : "ExecPort",
+      "metadata" : {
+        "uiPersistValue" : "true"
+        },
+      "name" : "bvhFile",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "FilePath"
+      },
+    {
+      "objectType" : "ExecPort",
+      "metadata" : {
+        "uiPersistValue" : "true"
+        },
+      "name" : "bvhNameTemp",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "FilePath"
+      },
+    {
+      "objectType" : "ExecPort",
+      "metadata" : {
+        "uiPersistValue" : "true"
+        },
+      "name" : "fbxFile",
+      "nodePortType" : "Out",
+      "execPortType" : "In"
+      },
+    {
+      "objectType" : "ExecPort",
+      "metadata" : {
+        "uiPersistValue" : "true"
+        },
+      "name" : "fbxNameTemp",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "FilePath"
+      },
+    {
+      "objectType" : "ExecPort",
+      "name" : "timeline",
+      "nodePortType" : "Out",
+      "execPortType" : "In",
+      "typeSpec" : "Float32"
+      }
+    ],
+  "extDeps" : {
+    "fabricUtils" : "*"
+    },
+  "nodes" : [
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":516.404785156,\"y\":85.31956052779999}"
+        },
+      "name" : "FileBrowser_1",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "filePath",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "result",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "Fabric.Compounds.IO.FileBrowser",
+      "presetGUID" : "ED70D3DF7C2BBE104B6E0DA12E8626BF"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":700.825683594,\"y\":334.971374512}",
+        "uiCollapsedState" : "1"
+        },
+      "name" : "LoadFBXCharacter2_1",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "filePath",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "String" : "${FABRIC_DIR}/Resources/Witcher_Creep.fbx"
+            }
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "scaleFactor",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "Scalar" : 18.5
+            }
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "time",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "animationMode",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "loopDuration",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "bindPose",
+          "nodePortType" : "Out"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "animation",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "fabricUtils.Characters.LoadFBXCharacter2",
+      "presetGUID" : "DA93DABCFDD4749D22A54E3F447E20F9"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":1289.49382019,\"y\":377.675848961}"
+        },
+      "name" : "DrawCharacter_1",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "character",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "color",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "this",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "fabricUtils.Characters.DrawCharacter",
+      "presetGUID" : "AC641CE6354807C722DEAE353CD1DBEA"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":566.825683594,\"y\":334.971374512}"
+        },
+      "name" : "FileBrowser_2",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "filePath",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "result",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "Fabric.Compounds.IO.FileBrowser",
+      "presetGUID" : "ED70D3DF7C2BBE104B6E0DA12E8626BF"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":747.731649876,\"y\":437.58510673}"
+        },
+      "name" : "FileBrowser_3",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "filePath",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "FilePath" : "C:/Users/gusta/OneDrive/Academia/Doutorado/Prototipo/resources/characterMaping - SMPL.json"
+            }
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "result",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "Fabric.Compounds.IO.FileBrowser",
+      "presetGUID" : "ED70D3DF7C2BBE104B6E0DA12E8626BF"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":741.24658525,\"y\":249.243869066}"
+        },
+      "name" : "FileBrowser_4",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "filePath",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "FilePath" : "C:/Users/gusta/OneDrive/Academia/Doutorado/Prototipo/resources/characterMaping - CMU.json"
+            }
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "result",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "Fabric.Compounds.IO.FileBrowser",
+      "presetGUID" : "ED70D3DF7C2BBE104B6E0DA12E8626BF"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":1172.8230921,\"y\":375.1355896}"
+        },
+      "name" : "SetPose_1",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "this",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "pose",
+          "nodePortType" : "In"
+          }
+        ],
+      "executable" : "Fabric.Exts.Characters.Character.SetPose",
+      "presetGUID" : "03D48EF598593C73963AF0A4F3828076"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":505.721653938,\"y\":182.344185352}",
+        "uiCollapsedState" : "1"
+        },
+      "name" : "FrameToTime_1",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "frame",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "fps",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "Float64" : 30
+            }
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "time",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "Fabric.Compounds.Math.FrameToTime",
+      "presetGUID" : "FC97B76DD3597484D4308A5490FD1853"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiComment" : "In this sample we are using BVH files\nfrom the CMU library and open sourche\ncharacters from the SMPL project.\nTo download the required files visit:\nhttp://sites.google.com/a/cgspeed.com/cgspeed/motion-capture\nhttp://smpl.is.tue.mpg.de/",
+        "uiGraphPos" : "{\"x\":932.628533602,\"y\":254.423123002}",
+        "uiCommentExpanded" : "true"
+        },
+      "name" : "BipedRetargetingSolver",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "drawDebug",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "scaleFactor",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "Scalar" : 1
+            }
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "inCharacter",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "inNameTemplate",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "outCharacter",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "outNameTemplate",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "inRefFrame",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "outRefFrame",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "retargetPose",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver",
+      "presetGUID" : "5BEE128DCD8CBA5159B569D2AF31778F"
+      },
+    {
+      "objectType" : "Inst",
+      "metadata" : {
+        "uiGraphPos" : "{\"x\":678.439522505,\"y\":103.514394403}"
+        },
+      "name" : "LoadCharacterFromBVH_1",
+      "ports" : [
+        {
+          "objectType" : "InstPort",
+          "name" : "exec",
+          "nodePortType" : "IO"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "file",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "timeMode",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "Integer" : 1
+            }
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "frame",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "time",
+          "nodePortType" : "In"
+          },
+        {
+          "objectType" : "InstPort",
+          "name" : "character",
+          "nodePortType" : "Out"
+          }
+        ],
+      "executable" : "fabricUtils.FileIO.BVHReader.LoadCharacterFromBVH",
+      "presetGUID" : "761E185980174E263149B02403F724D1"
+      }
+    ],
+  "connections" : {
+    "bvhFile" : [
+      "FileBrowser_1.filePath"
+      ],
+    "bvhNameTemp" : [
+      "FileBrowser_4.filePath"
+      ],
+    "fbxFile" : [
+      "FileBrowser_2.filePath"
+      ],
+    "fbxNameTemp" : [
+      "FileBrowser_3.filePath"
+      ],
+    "timeline" : [
+      "FrameToTime_1.frame"
+      ],
+    "FileBrowser_1.result" : [
+      "LoadCharacterFromBVH_1.file"
+      ],
+    "LoadFBXCharacter2_1.scaleFactor" : [
+      "BipedRetargetingSolver.scaleFactor"
+      ],
+    "LoadFBXCharacter2_1.animation" : [
+      "SetPose_1.this",
+      "BipedRetargetingSolver.outCharacter"
+      ],
+    "DrawCharacter_1.this" : [
+      "exec"
+      ],
+    "FileBrowser_2.result" : [
+      "LoadFBXCharacter2_1.filePath"
+      ],
+    "FileBrowser_3.result" : [
+      "BipedRetargetingSolver.outNameTemplate"
+      ],
+    "FileBrowser_4.result" : [
+      "BipedRetargetingSolver.inNameTemplate"
+      ],
+    "SetPose_1.this" : [
+      "DrawCharacter_1.character"
+      ],
+    "FrameToTime_1.time" : [
+      "LoadCharacterFromBVH_1.time"
+      ],
+    "BipedRetargetingSolver.retargetPose" : [
+      "SetPose_1.pose"
+      ],
+    "LoadCharacterFromBVH_1.character" : [
+      "BipedRetargetingSolver.inCharacter"
+      ]
+    },
+  "requiredPresets" : {
+    "Fabric.Compounds.IO.FileBrowser" : {
+      "objectType" : "Graph",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 20,\n  \"g\" : 20,\n  \"b\" : 20\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 121,\n  \"g\" : 134,\n  \"b\" : 143\n  }",
+        "uiGraphZoom" : "{\n  \"value\" : 1.0\n  }",
+        "uiGraphPan" : "{\n  \"x\" : 177.25,\n  \"y\" : -128.5\n  }"
+        },
+      "title" : "FileBrowser",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "defaultValues" : {
+            "Execute" : {}
+            },
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "filePath",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "FilePath" : null
+            },
+          "execPortType" : "In",
+          "typeSpec" : "FilePath"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "String" : ""
+            },
+          "execPortType" : "Out",
+          "typeSpec" : "String"
+          }
+        ],
+      "extDeps" : {
+        "FileIO" : "*"
+        },
+      "presetGUID" : "ED70D3DF7C2BBE104B6E0DA12E8626BF",
+      "nodes" : [
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":559.0,\"y\":274.0}"
+            },
+          "name" : "String",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FileIO.Func.String",
+          "presetGUID" : "D9AB202CD74F2E03B3068BD64DFE55D1"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":372.0,\"y\":275.0}"
+            },
+          "name" : "ExpandEnvVars",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FileIO.FilePath.ExpandEnvVars",
+          "presetGUID" : "9283C176D52B33D143DF71F9F6625F33"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":374.75,\"y\":177.5}"
+            },
+          "name" : "IsNull_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "obj",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Core.Object.IsNull",
+          "presetGUID" : "84AEE2708BDEAAFDEBA207A1733A052F"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":729.75,\"y\":197.5}"
+            },
+          "name" : "If_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "cond",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "if_true",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "if_false",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Core.Control.If",
+          "presetGUID" : "3182A478A21643455D549E483D35F831"
+          }
+        ],
+      "connections" : {
+        "filePath" : [
+          "ExpandEnvVars.this",
+          "IsNull_1.obj"
+          ],
+        "String.result" : [
+          "If_1.if_false"
+          ],
+        "ExpandEnvVars.result" : [
+          "String.this"
+          ],
+        "IsNull_1.result" : [
+          "If_1.cond"
+          ],
+        "If_1.result" : [
+          "result"
+          ]
+        }
+      },
+    "Fabric.Exts.FileIO.Func.String" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/FileIO/FileTime.html",
+        "uiTooltip" : "returns the time as a string, in the format \"YYYY-MM-DD HH-MM-SS\"\n\n Supported by FileTime,FilePath"
+        },
+      "title" : "String",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "String"
+          }
+        ],
+      "extDeps" : {
+        "FileIO" : "*"
+        },
+      "presetGUID" : "D9AB202CD74F2E03B3068BD64DFE55D1",
+      "code" : "require FileIO;
+
+dfgEntry {
+  result = this.string();
+}
+"
+      },
+    "Fabric.Exts.FileIO.FilePath.ExpandEnvVars" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/FileIO/FilePath.html",
+        "uiTooltip" : "expands all contained env vars in the FilePath. Env vars have to be specified as ${VARIABLE}\n\n\n Supported by FilePath"
+        },
+      "title" : "ExpandEnvVars",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "FilePath"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "FilePath"
+          }
+        ],
+      "extDeps" : {
+        "FileIO" : "*"
+        },
+      "presetGUID" : "9283C176D52B33D143DF71F9F6625F33",
+      "code" : "require FileIO;
+
+dfgEntry {
+  result = this.expandEnvVars();
+}
+"
+      },
+    "Fabric.Core.Object.IsNull" : {
+      "objectType" : "Func",
+      "title" : "IsNull",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "obj",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "Boolean"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "84AEE2708BDEAAFDEBA207A1733A052F",
+      "code" : "
+dfgEntry {
+  result = !obj;
+}
+"
+      },
+    "Fabric.Core.Control.If" : {
+      "objectType" : "Func",
+      "title" : "If",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "cond",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Boolean"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "if_true",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "if_false",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "$TYPE$"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "3182A478A21643455D549E483D35F831",
+      "code" : "
+dfgEntry {
+	result = cond ? if_true : if_false;
+}
+"
+      },
+    "fabricUtils.Characters.LoadFBXCharacter2" : {
+      "objectType" : "Graph",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 20,\n  \"g\" : 20,\n  \"b\" : 20\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 120,\n  \"g\" : 130,\n  \"b\" : 144\n  }",
+        "uiGraphZoom" : "{\n  \"value\" : 0.7096176743507385\n  }",
+        "uiTooltip" : "Opens a .fbx file and outputs a character at the bind pose, as well as a animated clone of the character.",
+        "uiGraphPan" : "{\n  \"x\" : 59.07763621625782,\n  \"y\" : -299.8241760089641\n  }"
+        },
+      "title" : "LoadFBXCharacter2",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "defaultValues" : {
+            "Execute" : {}
+            },
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "filePath",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "String" : "C:\\Temp\\file1.fbx"
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiRange" : "(0.5, 10)"
+            },
+          "name" : "scaleFactor",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Float32" : 1
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "time",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Float64" : 2
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Float64"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiCombo" : "(\"Continuous\", \"Loop\")"
+            },
+          "name" : "animationMode",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Boolean" : false,
+            "Integer" : 0
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Integer"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "loopDuration",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Float32" : 2
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Float32"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "bindPose",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "Character" : null
+            },
+          "execPortType" : "Out",
+          "typeSpec" : "Character"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "animation",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "Character" : null
+            },
+          "execPortType" : "Out",
+          "typeSpec" : "Character"
+          }
+        ],
+      "extDeps" : {
+        "Geometry" : "*",
+        "FbxHelpers" : "*"
+        },
+      "presetGUID" : "DA93DABCFDD4749D22A54E3F447E20F9",
+      "nodes" : [
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":7.19287109375,\"y\":636.774291992}"
+            },
+          "name" : "FilePath",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "value",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FileIO.FilePath.FilePath",
+          "presetGUID" : "99F8F257D7FABE2353B3E7A635249DF8"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":121.192871094,\"y\":636.774291992}"
+            },
+          "name" : "ExpandEnvVars",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FileIO.FilePath.ExpandEnvVars",
+          "presetGUID" : "9283C176D52B33D143DF71F9F6625F33"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":279.192871094,\"y\":636.774291992}"
+            },
+          "name" : "String",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FileIO.Func.String",
+          "presetGUID" : "D9AB202CD74F2E03B3068BD64DFE55D1"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":389.692871094,\"y\":555.774291992}"
+            },
+          "name" : "FbxCharacter",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "filePath",
+              "nodePortType" : "In",
+              "defaultValues" : {
+                "String" : ""
+                }
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FbxHelpers.FbxCharacter.FbxCharacter",
+          "presetGUID" : "44271B1C32345FA5677CEB1A06E4F4FD"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1172.73232174,\"y\":717.502752304}"
+            },
+          "name" : "ToCharacter",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FbxHelpers.FbxCharacter.ToCharacter",
+          "presetGUID" : "D8AC4D744C2C887B5A9DB075639FB2A9"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1046.31227732,\"y\":726.036324024}"
+            },
+          "name" : "Cache_2",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "value",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "Fabric.Core.Data.Cache",
+          "presetGUID" : "D903AFD981FE9214C69943F542D5FD60"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":389.692871094,\"y\":636.774291992}"
+            },
+          "name" : "GetFilePath",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FbxHelpers.Func.GetFilePath",
+          "presetGUID" : "ADEC84FA14833E4D831FCF62CB3E3D3E"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":534.692871094,\"y\":585.274291992}"
+            },
+          "name" : "SetupFromAnimatedPose",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "filePath",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "scaleFactor",
+              "nodePortType" : "In",
+              "defaultValues" : {
+                "Float32" : 1
+                }
+              }
+            ],
+          "executable" : "Fabric.Exts.FbxHelpers.FbxCharacter.SetupFromAnimatedPose",
+          "presetGUID" : "0FE48665855D3CE210BEECBE0B5BD5D8"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1357.06186056,\"y\":736.942834854}"
+            },
+          "name" : "SetClipPoseTime",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "time",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "Fabric.Exts.Characters.Character.SetClipPoseTime",
+          "presetGUID" : "61A54402005662F78D1EB2B48DB39451"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":389.692871094,\"y\":717.774291992}"
+            },
+          "name" : "PassIn_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "value",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "Fabric.Core.Data.PassIn",
+          "presetGUID" : "3C33E1B42A2643A035DBAB718554227D"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":534.692871094,\"y\":688.274291992}"
+            },
+          "name" : "PassIn_3",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "value",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "Fabric.Core.Data.PassIn",
+          "presetGUID" : "3C33E1B42A2643A035DBAB718554227D"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":754.692871094,\"y\":739.774291992}"
+            },
+          "name" : "Mod_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "lhs",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "rhs",
+              "nodePortType" : "In",
+              "defaultValues" : {
+                "Float32" : 1
+                }
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Core.Math.Mod",
+          "presetGUID" : "E5F205DEC5163107785D0380F07CDB44"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":883.692871094,\"y\":699.274291992}"
+            },
+          "name" : "If_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "cond",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "if_true",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "if_false",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Core.Control.If",
+          "presetGUID" : "3182A478A21643455D549E483D35F831"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":754.692871094,\"y\":636.774291992}"
+            },
+          "name" : "ToBoolean_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "value",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "boolean",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Core.Func.ToBoolean",
+          "presetGUID" : "E3F4150E373A9F4000F8FE5216942051"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1176.36944449,\"y\":615.510315061}"
+            },
+          "name" : "GetSkeleton_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.Characters.Func.GetSkeleton",
+          "presetGUID" : "A6403CFCD4204EBC55E5EBF8999EF98E"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1545.1563406,\"y\":557.348389149}"
+            },
+          "name" : "XfoArrayToPose_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "xfos",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "fabricUtils.Converters.XfoArrayToPose",
+          "presetGUID" : "05B4CCDD3E66BA616C15D0BF09A6BCB8"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1164.56682932,\"y\":535.254206777}"
+            },
+          "name" : "GetPose_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.Characters.Func.GetPose",
+          "presetGUID" : "8065E200C220844A048E8F9F0072D751"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1703.10546875,\"y\":537.394454002}"
+            },
+          "name" : "SetPose_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "pose",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "Fabric.Exts.Characters.Character.SetPose",
+          "presetGUID" : "03D48EF598593C73963AF0A4F3828076"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1317.05263281,\"y\":611.938647747}"
+            },
+          "name" : "ReferencePoseToXfoArray_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.Converters.ReferencePoseToXfoArray",
+          "presetGUID" : "1824BE86699EC017CD01C158B73DEE9B"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":927.524714947,\"y\":562.528892994}"
+            },
+          "name" : "ToCharacter_2",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.FbxHelpers.FbxCharacter.ToCharacter",
+          "presetGUID" : "D8AC4D744C2C887B5A9DB075639FB2A9"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":797.199047089,\"y\":570.27081871}"
+            },
+          "name" : "Cache_3",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "value",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "Fabric.Core.Data.Cache",
+          "presetGUID" : "D903AFD981FE9214C69943F542D5FD60"
+          }
+        ],
+      "connections" : {
+        "filePath" : [
+          "FilePath.value"
+          ],
+        "scaleFactor" : [
+          "PassIn_1.value"
+          ],
+        "time" : [
+          "PassIn_3.value"
+          ],
+        "animationMode" : [
+          "ToBoolean_1.value"
+          ],
+        "loopDuration" : [
+          "Mod_1.rhs"
+          ],
+        "FilePath.result" : [
+          "ExpandEnvVars.this"
+          ],
+        "ExpandEnvVars.result" : [
+          "String.this"
+          ],
+        "String.result" : [
+          "FbxCharacter.filePath"
+          ],
+        "FbxCharacter.result" : [
+          "GetFilePath.this",
+          "SetupFromAnimatedPose.this"
+          ],
+        "ToCharacter.result" : [
+          "SetClipPoseTime.this"
+          ],
+        "Cache_2.value" : [
+          "ToCharacter.this"
+          ],
+        "GetFilePath.result" : [
+          "SetupFromAnimatedPose.filePath"
+          ],
+        "SetupFromAnimatedPose.this" : [
+          "Cache_2.value",
+          "Cache_3.value"
+          ],
+        "SetClipPoseTime.this" : [
+          "animation"
+          ],
+        "PassIn_1.value" : [
+          "SetupFromAnimatedPose.scaleFactor"
+          ],
+        "PassIn_3.value" : [
+          "Mod_1.lhs"
+          ],
+        "Mod_1.lhs" : [
+          "If_1.if_false"
+          ],
+        "Mod_1.result" : [
+          "If_1.if_true"
+          ],
+        "If_1.result" : [
+          "SetClipPoseTime.time"
+          ],
+        "ToBoolean_1.boolean" : [
+          "If_1.cond"
+          ],
+        "GetSkeleton_1.result" : [
+          "ReferencePoseToXfoArray_1.this"
+          ],
+        "XfoArrayToPose_1.this" : [
+          "SetPose_1.pose"
+          ],
+        "GetPose_1.this" : [
+          "SetPose_1.this"
+          ],
+        "GetPose_1.result" : [
+          "XfoArrayToPose_1.this"
+          ],
+        "SetPose_1.this" : [
+          "bindPose"
+          ],
+        "ReferencePoseToXfoArray_1.result" : [
+          "XfoArrayToPose_1.xfos"
+          ],
+        "ToCharacter_2.result" : [
+          "GetPose_1.this",
+          "GetSkeleton_1.this"
+          ],
+        "Cache_3.value" : [
+          "ToCharacter_2.this"
+          ]
+        }
+      },
+    "Fabric.Exts.FileIO.FilePath.FilePath" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/FileIO/FilePath.html",
+        "uiTooltip" : "standard constructor from string\n\n Supported by FilePath"
+        },
+      "title" : "FilePath",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "value",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "String"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "FilePath"
+          }
+        ],
+      "extDeps" : {
+        "FileIO" : "*"
+        },
+      "presetGUID" : "99F8F257D7FABE2353B3E7A635249DF8",
+      "code" : "require FileIO;
+
+dfgEntry {
+  result = FilePath(value);
+}
+"
+      },
+    "Fabric.Exts.FbxHelpers.FbxCharacter.FbxCharacter" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/FbxHelpers/FbxCharacter.html",
+        "uiTooltip" : "Constructor taking a file path to load the fbx file on disk\n\n Supported by FbxCharacter"
+        },
+      "title" : "FbxCharacter",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "filePath",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "String"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "FbxCharacter"
+          }
+        ],
+      "extDeps" : {
+        "FbxHelpers" : "*"
+        },
+      "presetGUID" : "44271B1C32345FA5677CEB1A06E4F4FD",
+      "code" : "require FbxHelpers;
+
+dfgEntry {
+  result = FbxCharacter(filePath);
+}
+"
+      },
+    "Fabric.Exts.FbxHelpers.FbxCharacter.ToCharacter" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/FbxHelpers/FbxCharacter.html",
+        "uiTooltip" : "returns this FBXCharacter as a character\n\n Supported by FbxCharacter"
+        },
+      "title" : "ToCharacter",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "FbxCharacter"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "Character"
+          }
+        ],
+      "extDeps" : {
+        "FbxHelpers" : "*"
+        },
+      "presetGUID" : "D8AC4D744C2C887B5A9DB075639FB2A9",
+      "code" : "require FbxHelpers;
+
+dfgEntry {
+  result = this.toCharacter();
+}
+"
+      },
+    "Fabric.Core.Data.Cache" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiNodeColor" : "{\n  \"r\" : 214,\n  \"g\" : 191,\n  \"b\" : 103\n  }",
+        "uiAlwaysShowDaisyChainPorts" : "true",
+        "uiHeaderColor" : "{\n  \"r\" : 188,\n  \"g\" : 129,\n  \"b\" : 83\n  }"
+        },
+      "title" : "Cache",
+      "cacheRule" : "always",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "value",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "D903AFD981FE9214C69943F542D5FD60",
+      "code" : "dfgEntry {
+}
+"
+      },
+    "Fabric.Exts.FbxHelpers.Func.GetFilePath" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/FbxHelpers/FbxCharacter.html",
+        "uiTooltip" : "Returns the file path of the fbx file.\n\n Supported by FbxCharacter,FbxClip"
+        },
+      "title" : "GetFilePath",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "String"
+          }
+        ],
+      "extDeps" : {
+        "FbxHelpers" : "*"
+        },
+      "presetGUID" : "ADEC84FA14833E4D831FCF62CB3E3D3E",
+      "code" : "require FbxHelpers;
+
+dfgEntry {
+  result = this.getFilePath();
+}
+"
+      },
+    "Fabric.Exts.FbxHelpers.FbxCharacter.SetupFromAnimatedPose" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/FbxHelpers/FbxCharacter.html",
+        "uiTooltip" : "sets up the FBXCharacter with a animated pose\n\n Supported by FbxCharacter"
+        },
+      "title" : "SetupFromAnimatedPose",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "FbxCharacter"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "filePath",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "String"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "scaleFactor",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Scalar" : 1
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          }
+        ],
+      "extDeps" : {
+        "FbxHelpers" : "*"
+        },
+      "presetGUID" : "0FE48665855D3CE210BEECBE0B5BD5D8",
+      "code" : "require FbxHelpers;
+
+dfgEntry {
+  this.setupFromAnimatedPose(filePath, scaleFactor);
+}
+"
+      },
+    "Fabric.Exts.Characters.Character.SetClipPoseTime" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/Characters/Character.html",
+        "uiTooltip" : "changes the time on the clip pose\n\n Supported by Character"
+        },
+      "title" : "SetClipPoseTime",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Character"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "time",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Float32"
+          }
+        ],
+      "extDeps" : {
+        "Characters" : "*"
+        },
+      "presetGUID" : "61A54402005662F78D1EB2B48DB39451",
+      "code" : "require Characters;
+
+dfgEntry {
+  this.setClipPoseTime(time);
+}
+"
+      },
+    "Fabric.Core.Data.PassIn" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiNodeColor" : "{\n  \"r\" : 214,\n  \"g\" : 191,\n  \"b\" : 103\n  }",
+        "uiAlwaysShowDaisyChainPorts" : "true",
+        "uiHeaderColor" : "{\n  \"r\" : 188,\n  \"g\" : 129,\n  \"b\" : 83\n  }"
+        },
+      "title" : "PassIn",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "value",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "3C33E1B42A2643A035DBAB718554227D",
+      "code" : "dfgEntry {
+}
+"
+      },
+    "Fabric.Core.Math.Mod" : {
+      "objectType" : "Func",
+      "title" : "Mod",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "lhs",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "rhs",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "$TYPE$"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "E5F205DEC5163107785D0380F07CDB44",
+      "code" : "
+dfgEntry {
+	result = lhs % rhs;
+}
+"
+      },
+    "Fabric.Core.Func.ToBoolean" : {
+      "objectType" : "Func",
+      "title" : "ToBoolean",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "value",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "boolean",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "Boolean"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "E3F4150E373A9F4000F8FE5216942051",
+      "code" : "dfgEntry {
+  boolean = Boolean(value);
+}
+"
+      },
+    "Fabric.Exts.Characters.Func.GetSkeleton" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/Characters/ICharacter.html",
+        "uiTooltip" : "\n\n Supported by ICharacter,Character"
+        },
+      "title" : "GetSkeleton",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "ISkeleton"
+          }
+        ],
+      "extDeps" : {
+        "Characters" : "*"
+        },
+      "presetGUID" : "A6403CFCD4204EBC55E5EBF8999EF98E",
+      "code" : "require Characters;
+
+dfgEntry {
+  result = this.getSkeleton();
+}
+"
+      },
+    "fabricUtils.Converters.XfoArrayToPose" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTooltip" : "Sets the xfos on a pose using an xfo array.\n\nSupported types:\n  this: IPose\n  xfos: Xfo[]\n"
+        },
+      "title" : "XfoArrayToPose",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "IPose"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiColor" : "{\n  \"r\" : 249,\n  \"g\" : 157,\n  \"b\" : 28\n  }"
+            },
+          "name" : "xfos",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Xfo[]"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "05B4CCDD3E66BA616C15D0BF09A6BCB8",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  xfoArrayToPose(this, xfos);
+}
+"
+      },
+    "Fabric.Exts.Characters.Func.GetPose" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/Characters/ICharacter.html",
+        "uiTooltip" : "\n\n Supported by ICharacter,Character"
+        },
+      "title" : "GetPose",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "IPose"
+          }
+        ],
+      "extDeps" : {
+        "Characters" : "*"
+        },
+      "presetGUID" : "8065E200C220844A048E8F9F0072D751",
+      "code" : "require Characters;
+
+dfgEntry {
+  result = this.getPose();
+}
+"
+      },
+    "Fabric.Exts.Characters.Character.SetPose" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/Characters/Character.html",
+        "uiTooltip" : "Sets a the pose object for this character.\n\n Supported by Character"
+        },
+      "title" : "SetPose",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Character"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "pose",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "IPose"
+          }
+        ],
+      "extDeps" : {
+        "Characters" : "*"
+        },
+      "presetGUID" : "03D48EF598593C73963AF0A4F3828076",
+      "code" : "require Characters;
+
+dfgEntry {
+  this.setPose(pose);
+}
+"
+      },
+    "fabricUtils.Converters.ReferencePoseToXfoArray" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTooltip" : "Gets the skeleton's reference pose into an array of Xfos.\n\nSupported types:\n  this: ISkeleton\n  result: Xfo[]\n"
+        },
+      "title" : "ReferencePoseToXfoArray",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "ISkeleton"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiColor" : "{\n  \"r\" : 249,\n  \"g\" : 157,\n  \"b\" : 28\n  }"
+            },
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "Xfo[]"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "1824BE86699EC017CD01C158B73DEE9B",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  result = referencePoseToXfoArray(this);
+}
+"
+      },
+    "fabricUtils.Characters.DrawCharacter" : {
+      "objectType" : "Graph",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 20,\n  \"g\" : 20,\n  \"b\" : 20\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 121,\n  \"g\" : 134,\n  \"b\" : 143\n  }",
+        "uiGraphZoom" : "{\n  \"value\" : 1.0\n  }",
+        "uiTooltip" : "Draws all the geometry in a given character.",
+        "uiGraphPan" : "{\n  \"x\" : -851.1322021484375,\n  \"y\" : 173.5998072624207\n  }"
+        },
+      "title" : "DrawCharacter",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "defaultValues" : {
+            "Execute" : {}
+            },
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "character",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Character" : null
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "color",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Color" : {
+              "r" : 0.7843137383460999,
+              "g" : 0.7843137383460999,
+              "b" : 0.7843137383460999,
+              "a" : 1
+              }
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Color"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "DrawingHandle" : null
+            },
+          "execPortType" : "Out"
+          }
+        ],
+      "extDeps" : {
+        "Characters" : "*"
+        },
+      "presetGUID" : "AC641CE6354807C722DEAE353CD1DBEA",
+      "nodes" : [
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1607.10445428,\"y\":-49.1809805632}",
+            "uiCollapsedState" : "0"
+            },
+          "name" : "DrawMeshArray",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "color",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.Draw.DrawMeshArray",
+          "presetGUID" : "DCF604F9BDF2080AA8A92B302A65EE3D"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1357.15989006,\"y\":2.98136615753}"
+            },
+          "name" : "GetAllDeformedMesh_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.Characters.GetAllDeformedMesh",
+          "presetGUID" : "6060124EAC56DDD0137FB85EA77EDAC2"
+          }
+        ],
+      "connections" : {
+        "character" : [
+          "GetAllDeformedMesh_1.this"
+          ],
+        "color" : [
+          "DrawMeshArray.color"
+          ],
+        "DrawMeshArray.this" : [
+          "this"
+          ],
+        "GetAllDeformedMesh_1.result" : [
+          "DrawMeshArray.result"
+          ]
+        }
+      },
+    "fabricUtils.Draw.DrawMeshArray" : {
+      "objectType" : "Graph",
+      "metadata" : {
+        "uiGraphZoom" : "{\n  \"value\" : 0.9400274157524109\n  }",
+        "uiGraphPan" : "{\n  \"x\" : -858.7704467773438,\n  \"y\" : 185.8662719726563\n  }"
+        },
+      "title" : "DrawMeshArray",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "defaultValues" : {
+            "Execute" : {}
+            },
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "PolygonMesh[]" : []
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "color",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Color" : {
+              "r" : 0.7843137383460999,
+              "g" : 0.7843137383460999,
+              "b" : 0.7843137383460999,
+              "a" : 1
+              }
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Color"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "DrawingHandle" : null
+            },
+          "execPortType" : "Out"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "DCF604F9BDF2080AA8A92B302A65EE3D",
+      "nodes" : [
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1670.13303304,\"y\":-144.811741114}"
+            },
+          "name" : "DrawPolygonMeshArray_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "name",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "color",
+              "nodePortType" : "In",
+              "defaultValues" : {
+                "Color" : {
+                  "r" : 0.7843137383460999,
+                  "g" : 0.7843137383460999,
+                  "b" : 0.7843137383460999,
+                  "a" : 1
+                  }
+                }
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "specular",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "specFactor",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "masters",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "transforms",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "indices",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "wireFrame",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "doubleSided",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "dummyResult",
+              "nodePortType" : "Out"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "instance",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.InlineDrawing.DrawingHandle.DrawPolygonMeshArray",
+          "presetGUID" : "C5D3967A103CAE41AF99EA35D2D636A8"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":1410.7719506,\"y\":-205.667884111}"
+            },
+          "name" : "EmptyDrawingHandle",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "handle",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.InlineDrawing.DrawingHandle.EmptyDrawingHandle",
+          "presetGUID" : "2440020BA6A1CAB1CEB690A198F99C70"
+          }
+        ],
+      "connections" : {
+        "result" : [
+          "DrawPolygonMeshArray_1.masters"
+          ],
+        "color" : [
+          "DrawPolygonMeshArray_1.color"
+          ],
+        "DrawPolygonMeshArray_1.this" : [
+          "this"
+          ],
+        "EmptyDrawingHandle.handle" : [
+          "DrawPolygonMeshArray_1.this"
+          ]
+        }
+      },
+    "Fabric.Exts.InlineDrawing.DrawingHandle.DrawPolygonMeshArray" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTooltip" : "Helper function for the InlineDrawing DrawingHandle data type\nto draw a list of objects given an index table and a list of\ntransforms.\n\nSupported types:\n  this: DrawingHandle\n  name: String\n  color: Color\n  specular: Color\n  specFactor: Float32\n  masters: PolygonMesh[]\n  transforms: Xfo[]\n  indices: Index[]\n  wireFrame: Boolean\n  doubleSided: Boolean\n  dummyResult: Vec3\n  instance: InlineInstance\n"
+        },
+      "title" : "DrawPolygonMeshArray",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "DrawingHandle"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "name",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "String"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiColor" : "{\n  \"r\" : 255,\n  \"g\" : 0,\n  \"b\" : 0\n  }"
+            },
+          "name" : "color",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Color" : {
+              "r" : 0,
+              "g" : 1,
+              "b" : 0,
+              "a" : 1
+              }
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Color"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiColor" : "{\n  \"r\" : 255,\n  \"g\" : 0,\n  \"b\" : 0\n  }"
+            },
+          "name" : "specular",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Color" : {
+              "r" : 0.2000000029802322,
+              "g" : 0.2000000029802322,
+              "b" : 0.2000000029802322,
+              "a" : 1
+              }
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Color"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "specFactor",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Float32" : 16
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Float32"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiColor" : "{\n  \"r\" : 51,\n  \"g\" : 1,\n  \"b\" : 106\n  }"
+            },
+          "name" : "masters",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "PolygonMesh[]"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiColor" : "{\n  \"r\" : 249,\n  \"g\" : 157,\n  \"b\" : 28\n  }"
+            },
+          "name" : "transforms",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Xfo[]"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "indices",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Index[]"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "wireFrame",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Boolean"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "doubleSided",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Boolean"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiColor" : "{\n  \"r\" : 255,\n  \"g\" : 242,\n  \"b\" : 0\n  }"
+            },
+          "name" : "dummyResult",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "Vec3"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "instance",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "InlineInstance"
+          }
+        ],
+      "extDeps" : {
+        "InlineDrawing" : "*",
+        "FabricInterfaces" : "*"
+        },
+      "presetGUID" : "C5D3967A103CAE41AF99EA35D2D636A8",
+      "code" : "require InlineDrawing;
+
+dfgEntry {
+  this.drawPolygonMeshArray(name, color, specular, specFactor, masters, transforms, indices, wireFrame, doubleSided, dummyResult, instance);
+}
+"
+      },
+    "Fabric.Exts.InlineDrawing.DrawingHandle.EmptyDrawingHandle" : {
+      "objectType" : "Graph",
+      "title" : "EmptyDrawingHandle",
+      "cacheRule" : "never",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "handle",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "DrawingHandle"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "2440020BA6A1CAB1CEB690A198F99C70",
+      "nodes" : [
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\": 894, \"y\": 100}"
+            },
+          "name" : "Clear",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              }
+            ],
+          "cacheRule" : "never",
+          "executable" : "Fabric.Exts.InlineDrawing.DrawingHandle.Clear",
+          "presetGUID" : "39E8D81FA7C7C4A825877F16EFE3564F"
+          },
+        {
+          "objectType" : "Var",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":567.0,\"y\":56.0}",
+            "uiCollapsedState" : "0"
+            },
+          "name" : "handleVar",
+          "ports" : [
+            {
+              "objectType" : "VarPort",
+              "name" : "value",
+              "nodePortType" : "IO"
+              }
+            ],
+          "dataType" : "DrawingHandle",
+          "extDep" : "InlineDrawing:*"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":287.0,\"y\":56.0}"
+            },
+          "name" : "CreateDrawingHandle",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "handle",
+              "nodePortType" : "Out"
+              }
+            ],
+          "definition" : {
+            "objectType" : "Func",
+            "title" : "Create DrawingHandle",
+            "ports" : [
+              {
+                "objectType" : "ExecPort",
+                "name" : "exec",
+                "nodePortType" : "IO",
+                "execPortType" : "IO",
+                "typeSpec" : "Execute"
+                },
+              {
+                "objectType" : "ExecPort",
+                "name" : "handle",
+                "nodePortType" : "In",
+                "execPortType" : "Out",
+                "typeSpec" : "DrawingHandle"
+                }
+              ],
+            "extDeps" : {
+              "InlineDrawing" : "*"
+              },
+            "code" : "dfgEntry {
+  handle = DrawingHandle();
+}
+"
+            }
+          }
+        ],
+      "connections" : {
+        "Clear.this" : [
+          "handle"
+          ],
+        "handleVar.value" : [
+          "Clear.this"
+          ],
+        "CreateDrawingHandle.handle" : [
+          "handleVar.value"
+          ]
+        }
+      },
+    "Fabric.Exts.InlineDrawing.DrawingHandle.Clear" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiDocUrl" : "http://docs.fabric-engine.com/FabricEngine/2.3.0/HTML/KLExtensionsGuide/InlineDrawing/DrawingHandle.html",
+        "uiTooltip" : "removes all contents from the DrawingHandle\n\n Supported by DrawingHandle"
+        },
+      "title" : "Clear",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "DrawingHandle"
+          }
+        ],
+      "extDeps" : {
+        "InlineDrawing" : "*"
+        },
+      "presetGUID" : "39E8D81FA7C7C4A825877F16EFE3564F",
+      "code" : "require InlineDrawing;
+
+dfgEntry {
+  this.clear();
+}
+"
+      },
+    "fabricUtils.Characters.GetAllDeformedMesh" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTooltip" : "Gets a deformed copy of all meshes in a character.\n\nSupported types:\n  this: Character\n  result: PolygonMesh[]\n"
+        },
+      "title" : "GetAllDeformedMesh",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Character"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiColor" : "{\n  \"r\" : 51,\n  \"g\" : 1,\n  \"b\" : 106\n  }"
+            },
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "PolygonMesh[]"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "6060124EAC56DDD0137FB85EA77EDAC2",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  getAllDeformedMesh(this, result);
+}
+"
+      },
+    "Fabric.Compounds.Math.FrameToTime" : {
+      "objectType" : "Graph",
+      "metadata" : {
+        "uiTooltip" : "converts the input frame and framerate into time (in seconds)",
+        "uiGraphPan" : "{\"x\": 88, \"y\": -23}"
+        },
+      "title" : "FrameToTime",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiRange" : "(0, 100)"
+            },
+          "name" : "frame",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Float64" : 0
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Float64"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiRange" : "(1, 50)"
+            },
+          "name" : "fps",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Float64" : 24
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Float64"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "time",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "Float64"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "FC97B76DD3597484D4308A5490FD1853",
+      "nodes" : [
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\": 273, \"y\": 124}",
+            "uiCollapsedState" : "2"
+            },
+          "name" : "MathMax",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "val1",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "val2",
+              "nodePortType" : "In",
+              "defaultValues" : {
+                "Float64" : 0.001000000047497451
+                }
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Exts.Math.Func.Math_max",
+          "presetGUID" : "2BA355E40799979F7BA995D89A07F1A5"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\": 415, \"y\": 51}"
+            },
+          "name" : "Div",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "lhs",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "rhs",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Core.Math.Div",
+          "presetGUID" : "695E8145F8F42293FBC88BD348869892"
+          }
+        ],
+      "connections" : {
+        "frame" : [
+          "Div.lhs"
+          ],
+        "fps" : [
+          "MathMax.val1"
+          ],
+        "MathMax.result" : [
+          "Div.rhs"
+          ],
+        "Div.result" : [
+          "time"
+          ]
+        }
+      },
+    "Fabric.Exts.Math.Func.Math_max" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiNodeColor" : "{\n  \"r\" : 99,\n  \"g\" : 129,\n  \"b\" : 92\n  }",
+        "uiTooltip" : "Returns the maximum of two scalar values\n\n Supported by Scalar,Float64"
+        },
+      "title" : "Math_max",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "val1",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "val2",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "$TYPE$"
+          }
+        ],
+      "extDeps" : {
+        "Math" : "*"
+        },
+      "presetGUID" : "2BA355E40799979F7BA995D89A07F1A5",
+      "code" : "require Math;
+
+dfgEntry {
+  result = Math_max(val1, val2);
+}
+"
+      },
+    "Fabric.Core.Math.Div" : {
+      "objectType" : "Func",
+      "title" : "Div",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "lhs",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "rhs",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "$TYPE$"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "$TYPE$"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "695E8145F8F42293FBC88BD348869892",
+      "code" : "
+dfgEntry {
+	result = lhs / rhs;
+}
+"
+      },
+    "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver" : {
+      "objectType" : "Graph",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 59,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+        "uiGraphZoom" : "{\n  \"value\" : 0.5480090379714966\n  }",
+        "uiTooltip" : "Retargets the current pose of a biped character based on the pose of another biped character. Mappings are defined using JSON files and MotionBuilder naming convention. The offset between character joints is defined based on the poses at a given reference frame.",
+        "uiGraphPan" : "{\n  \"x\" : -240.7455219868316,\n  \"y\" : 189.3113026456799\n  }"
+        },
+      "title" : "BipedRetargetingSolver",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "defaultValues" : {
+            "Execute" : {}
+            },
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "drawDebug",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Boolean" : false
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Boolean"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "scaleFactor",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Scalar" : 1
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inCharacter",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "ICharacter" : null
+            },
+          "execPortType" : "In",
+          "typeSpec" : "ICharacter"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inNameTemplate",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "String" : ""
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outCharacter",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Character" : null
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outNameTemplate",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "String" : ""
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inRefFrame",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Scalar" : 0
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outRefFrame",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Scalar" : 0
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "retargetPose",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "IPose" : null
+            },
+          "execPortType" : "Out"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "5BEE128DCD8CBA5159B569D2AF31778F",
+      "nodes" : [
+        {
+          "objectType" : "Var",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":800.413125277,\"y\":132.23861742}"
+            },
+          "name" : "solver",
+          "ports" : [
+            {
+              "objectType" : "VarPort",
+              "name" : "value",
+              "nodePortType" : "IO"
+              }
+            ],
+          "dataType" : "BipedRetargetingSolver"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":473.980339527,\"y\":127.584055901}"
+            },
+          "name" : "BipedRetargetingSolver_Constructor_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Constructor",
+          "presetGUID" : "5DA31A7CEEF572CC1872C28626061AC2"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":917.399583817,\"y\":160.117748737}"
+            },
+          "name" : "BipedRetargetingSolver_Solve_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "drawDebug",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "scaleFactor",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "inCharacter",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "outCharacter",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "inNameTemplate",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "outNameTemplate",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "inRefFrame",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "outRefFrame",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "retargetPose",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Solve",
+          "presetGUID" : "27B880C6D5A791F0E845044FA61D58F7"
+          }
+        ],
+      "connections" : {
+        "drawDebug" : [
+          "BipedRetargetingSolver_Solve_1.drawDebug"
+          ],
+        "scaleFactor" : [
+          "BipedRetargetingSolver_Solve_1.scaleFactor"
+          ],
+        "inCharacter" : [
+          "BipedRetargetingSolver_Solve_1.inCharacter"
+          ],
+        "inNameTemplate" : [
+          "BipedRetargetingSolver_Solve_1.inNameTemplate"
+          ],
+        "outCharacter" : [
+          "BipedRetargetingSolver_Solve_1.outCharacter"
+          ],
+        "outNameTemplate" : [
+          "BipedRetargetingSolver_Solve_1.outNameTemplate"
+          ],
+        "inRefFrame" : [
+          "BipedRetargetingSolver_Solve_1.inRefFrame"
+          ],
+        "outRefFrame" : [
+          "BipedRetargetingSolver_Solve_1.outRefFrame"
+          ],
+        "solver.value" : [
+          "BipedRetargetingSolver_Solve_1.this"
+          ],
+        "BipedRetargetingSolver_Constructor_1.result" : [
+          "solver.value"
+          ],
+        "BipedRetargetingSolver_Solve_1.retargetPose" : [
+          "retargetPose"
+          ]
+        }
+      },
+    "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Constructor" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 49,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+        "uiHeaderColor" : "{\n  \"r\" : 42,\n  \"g\" : 94,\n  \"b\" : 102\n  }",
+        "uiTooltip" : "Supported types:\n  result: BipedRetargetingSolver\n"
+        },
+      "title" : "BipedRetargetingSolver_Constructor",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "BipedRetargetingSolver"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "5DA31A7CEEF572CC1872C28626061AC2",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  result = BipedRetargetingSolver();
+}
+"
+      },
+    "fabricUtils.Kinematics.BipedRetargtingSolver.BipedRetargetingSolver_Solve" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTextColor" : "{\n  \"r\" : 168,\n  \"g\" : 229,\n  \"b\" : 240\n  }",
+        "uiNodeColor" : "{\n  \"r\" : 49,\n  \"g\" : 60,\n  \"b\" : 61\n  }",
+        "uiHeaderColor" : "{\n  \"r\" : 42,\n  \"g\" : 94,\n  \"b\" : 102\n  }",
+        "uiTooltip" : "Supported types:\n  this: BipedRetargetingSolver\n  drawDebug: Boolean\n  scaleFactor: Scalar\n  inCharacter: ICharacter\n  outCharacter: ICharacter\n  inNameTemplate: FilePath\n  outNameTemplate: FilePath\n  inRefFrame: Scalar\n  outRefFrame: Scalar\n  retargetPose: IPose\n"
+        },
+      "title" : "BipedRetargetingSolver_Solve",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "BipedRetargetingSolver"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "drawDebug",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Boolean"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "scaleFactor",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inCharacter",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "ICharacter"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outCharacter",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "ICharacter"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inNameTemplate",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "FilePath"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outNameTemplate",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "FilePath"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "inRefFrame",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "outRefFrame",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "retargetPose",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "IPose"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "27B880C6D5A791F0E845044FA61D58F7",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  this.solve(drawDebug, scaleFactor, inCharacter, outCharacter, inNameTemplate, outNameTemplate, inRefFrame, outRefFrame, retargetPose);
+}
+"
+      },
+    "fabricUtils.FileIO.BVHReader.LoadCharacterFromBVH" : {
+      "objectType" : "Graph",
+      "metadata" : {
+        "uiGraphZoom" : "{\n  \"value\" : 0.7049185633659363\n  }",
+        "uiGraphPan" : "{\n  \"x\" : 53.78642077285667,\n  \"y\" : 8.085334168210466\n  }"
+        },
+      "title" : "LoadCharacterFromBVH",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "defaultValues" : {
+            "Execute" : {}
+            },
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "file",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "String" : ""
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "metadata" : {
+            "uiCombo" : "(\"Use original FPS (frames port)\", \"Use custom FPS (time port)\")"
+            },
+          "name" : "timeMode",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Boolean" : false,
+            "Integer" : 0
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Integer"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "frame",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Float32" : 0
+            },
+          "execPortType" : "In"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "time",
+          "nodePortType" : "Out",
+          "defaultValues" : {
+            "Scalar" : 0
+            },
+          "execPortType" : "In",
+          "typeSpec" : "Scalar"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "character",
+          "nodePortType" : "In",
+          "defaultValues" : {
+            "Character" : null
+            },
+          "execPortType" : "Out"
+          }
+        ],
+      "extDeps" : {},
+      "presetGUID" : "761E185980174E263149B02403F724D1",
+      "nodes" : [
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":-30.9062957764,\"y\":241.036437988}"
+            },
+          "name" : "BVHReader_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "filePath",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.FileIO.BVHReader.BVHReader",
+          "presetGUID" : "BAB82AFA00686CB9D8707126EF0D1CDE"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":430.674414158,\"y\":416.325568557}"
+            },
+          "name" : "FrameToTime_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "frame",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "fps",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "time",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Compounds.Math.FrameToTime",
+          "presetGUID" : "FC97B76DD3597484D4308A5490FD1853"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":102.093704224,\"y\":241.036437988}"
+            },
+          "name" : "Cache_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "value",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "Fabric.Core.Data.Cache",
+          "presetGUID" : "D903AFD981FE9214C69943F542D5FD60"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":216.093704224,\"y\":241.036437988}"
+            },
+          "name" : "GetCharacter_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.FileIO.BVHReader.GetCharacter",
+          "presetGUID" : "BA0245F136C565F5AD2810B4392B8DCA"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":716.837146044,\"y\":263.674444675}"
+            },
+          "name" : "SetClipPoseTime_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "time",
+              "nodePortType" : "In"
+              }
+            ],
+          "executable" : "Fabric.Exts.Characters.Character.SetClipPoseTime",
+          "presetGUID" : "61A54402005662F78D1EB2B48DB39451"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":228.249192238,\"y\":342.89778316}"
+            },
+          "name" : "GetFPS_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "this",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "fabricUtils.FileIO.BVHReader.GetFPS",
+          "presetGUID" : "2C242FB01B1F0AD3FCBD4FD5F87A3890"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":429.553672433,\"y\":325.165848136}",
+            "uiCollapsedState" : "2"
+            },
+          "name" : "ToBoolean_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "value",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "boolean",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Core.Func.ToBoolean",
+          "presetGUID" : "E3F4150E373A9F4000F8FE5216942051"
+          },
+        {
+          "objectType" : "Inst",
+          "metadata" : {
+            "uiGraphPos" : "{\"x\":569.0,\"y\":320.5}"
+            },
+          "name" : "If_1",
+          "ports" : [
+            {
+              "objectType" : "InstPort",
+              "name" : "exec",
+              "nodePortType" : "IO"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "cond",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "if_true",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "if_false",
+              "nodePortType" : "In"
+              },
+            {
+              "objectType" : "InstPort",
+              "name" : "result",
+              "nodePortType" : "Out"
+              }
+            ],
+          "executable" : "Fabric.Core.Control.If",
+          "presetGUID" : "3182A478A21643455D549E483D35F831"
+          }
+        ],
+      "connections" : {
+        "file" : [
+          "BVHReader_1.filePath"
+          ],
+        "timeMode" : [
+          "ToBoolean_1.value"
+          ],
+        "frame" : [
+          "FrameToTime_1.frame"
+          ],
+        "time" : [
+          "If_1.if_true"
+          ],
+        "BVHReader_1.result" : [
+          "Cache_1.value"
+          ],
+        "FrameToTime_1.time" : [
+          "If_1.if_false"
+          ],
+        "Cache_1.value" : [
+          "GetCharacter_1.this",
+          "GetFPS_1.this"
+          ],
+        "GetCharacter_1.result" : [
+          "SetClipPoseTime_1.this"
+          ],
+        "SetClipPoseTime_1.this" : [
+          "character"
+          ],
+        "GetFPS_1.result" : [
+          "FrameToTime_1.fps"
+          ],
+        "ToBoolean_1.boolean" : [
+          "If_1.cond"
+          ],
+        "If_1.result" : [
+          "SetClipPoseTime_1.time"
+          ]
+        }
+      },
+    "fabricUtils.FileIO.BVHReader.BVHReader" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTooltip" : "BVH reader, default constructor\n\nSupported types:\n  filePath: FilePath\n  result: BVHReader\n"
+        },
+      "title" : "BVHReader",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "filePath",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "FilePath"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "BVHReader"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "BAB82AFA00686CB9D8707126EF0D1CDE",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  result = BVHReader(filePath);
+}
+"
+      },
+    "fabricUtils.FileIO.BVHReader.GetCharacter" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTooltip" : "Outputs the character with a skeleton and all its motion clips.\n\nSupported types:\n  this: BVHReader\n  result: Character\n"
+        },
+      "title" : "GetCharacter",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "BVHReader"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "Character"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "BA0245F136C565F5AD2810B4392B8DCA",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  result = this.getCharacter();
+}
+"
+      },
+    "fabricUtils.FileIO.BVHReader.GetFPS" : {
+      "objectType" : "Func",
+      "metadata" : {
+        "uiTooltip" : "Outputs the BVH's FPS.\n\nSupported types:\n  this: BVHReader\n  result: Scalar\n"
+        },
+      "title" : "GetFPS",
+      "ports" : [
+        {
+          "objectType" : "ExecPort",
+          "name" : "exec",
+          "nodePortType" : "IO",
+          "execPortType" : "IO",
+          "typeSpec" : "Execute"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "this",
+          "nodePortType" : "Out",
+          "execPortType" : "In",
+          "typeSpec" : "BVHReader"
+          },
+        {
+          "objectType" : "ExecPort",
+          "name" : "result",
+          "nodePortType" : "In",
+          "execPortType" : "Out",
+          "typeSpec" : "Scalar"
+          }
+        ],
+      "extDeps" : {
+        "fabricUtils" : "*"
+        },
+      "presetGUID" : "2C242FB01B1F0AD3FCBD4FD5F87A3890",
+      "code" : "require fabricUtils;
+
+dfgEntry {
+  result = this.getFPS();
+}
+"
+      }
+    },
+  "args" : [
+    {
+      "type" : "FilePath",
+      "value" : "C:/Users/gusta/OneDrive/Academia/Doutorado/Prototipo/animacao/CMU/01/01_01.bvh",
+      "ext" : "FileIO"
+      },
+    {
+      "type" : "FilePath",
+      "value" : "C:/Users/gusta/OneDrive/Academia/Doutorado/Prototipo/resources/characterMaping - CMU.json",
+      "ext" : "FileIO"
+      },
+    {
+      "type" : "FilePath",
+      "value" : "C:/Users/gusta/Downloads/SMPL_maya/basicModel_m_lbs_10_207_0_v1.0.2.fbx",
+      "ext" : "FileIO"
+      },
+    {
+      "type" : "FilePath",
+      "value" : "C:/Users/gusta/OneDrive/Software/Portateis/MyFabricExts/fabricUtils/Samples/characterMaping - SMPLmale.json",
+      "ext" : "FileIO"
+      },
+    {
+      "type" : "Float32",
+      "value" : null
+      }
+    ]
+  }

--- a/fabricUtils.fpm.json
+++ b/fabricUtils.fpm.json
@@ -8,6 +8,7 @@
 
   	"Characters/getAllDeformedMesh.kl",
 
+    "Converters/boneIDArrayToParentIDArray.kl",
     "Converters/boneNameArrayToIDArray.kl",
   	"Converters/poseToXfoArray.kl",
     "Converters/quatStringToXfoArray.kl",
@@ -18,6 +19,7 @@
     "FileIO/getClipPoseFromQuatCSV.kl",
     "FileIO/BVHReader.kl",
 
+    "Kinematics/BipedRetargetingSolver.kl"
     //"Kinematics/FootstepConstraintSolver.kl"
 
     // other


### PR DESCRIPTION
A very basic biped retargeting solver that uses motionbuilder name mapping for transfering motion. No techniqes to prevent footskating are implemented at the moment.
